### PR TITLE
Ensure user info saved regardless of capture count

### DIFF
--- a/face_api.py
+++ b/face_api.py
@@ -219,8 +219,8 @@ def capture_face():
         if not saved_faces:
             return jsonify({'success': False, 'message': 'Không phát hiện khuôn mặt trong ảnh'})
         
-        # Lưu thông tin user vào database (chỉ lần đầu)
-        if image_count == 1 and user_info:
+        # Lưu hoặc cập nhật thông tin user vào database
+        if user_info:
             try:
                 conn = face_api.get_db_connection()
                 if conn:
@@ -229,15 +229,15 @@ def capture_face():
                         INSERT INTO admin_faces (user_id, email, full_name, role_name, created_at, updated_at)
                         VALUES (%s, %s, %s, %s, %s, %s)
                         ON DUPLICATE KEY UPDATE
-                        email = VALUES(email),
-                        full_name = VALUES(full_name),
-                        role_name = VALUES(role_name),
-                        updated_at = VALUES(updated_at)
+                            email = VALUES(email),
+                            full_name = VALUES(full_name),
+                            role_name = VALUES(role_name),
+                            updated_at = VALUES(updated_at)
                     """, (
                         user_id,
                         user_info.get('email'),
                         user_info.get('full_name'),
-                        user_info.get('role'),
+                        user_info.get('role') or user_info.get('role_name'),
                         datetime.now(),
                         datetime.now()
                     ))


### PR DESCRIPTION
## Summary
- Store or update user metadata on every capture instead of only the first
- Accept `role_name` field when saving to database

## Testing
- `python -m py_compile face_api.py`
- `python -m py_compile 01_face_dataset.py 02_face_training.py 03_face_recognition.py`


------
https://chatgpt.com/codex/tasks/task_e_68a42aaafa688326a6a3cd0ec26897ba